### PR TITLE
Reaching maximum calls stack when copying non-js files in babel-cli

### DIFF
--- a/packages/babel-cli/src/babel/dir.js
+++ b/packages/babel-cli/src/babel/dir.js
@@ -13,7 +13,7 @@ export default function(commander, filenames, opts) {
       base = undefined;
     }
     if (!util.isCompilableExtension(relative, commander.extensions)) {
-      return callback();
+      return process.nextTick(callback);
     }
 
     // remove extension and then append back on .js


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR         | No
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

`@babel/cli@7.0.0-beta.39` and `@babel/cli@7.0.0-beta.38` has bug, it cannot copy large number of files with non-compilable extensions, when using with `--copy-files`, due to reaching maximum size of call stack